### PR TITLE
Add maxspeed argument, allow passing an array of break times

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,23 +7,24 @@ var isolines = require('turf-isolines'),
     polylineDecode = require('polyline').decode,
     OSRM = require('osrm');
 
-module.exports = function (center, time, resolution, network, done) {
+module.exports = function (center, times, resolution, maxspeed, network, done) {
     var osrm = new OSRM(network);
+    times = Array.isArray(times) ? times : [times];
+    var time = times[times.length - 1];
     // compute bbox
     // bbox should go out 1.4 miles in each direction for each minute
     // this will account for a driver going a bit above the max safe speed
     var centerPt = point(center[0], center[1]);
-    var spokes = featureCollection([])
-    var miles = (time/60) * 1.2; // assume 70mph max speed
-    spokes.features.push(destination(centerPt, miles, 180, 'miles'));
-    spokes.features.push(destination(centerPt, miles, 0, 'miles'));
-    spokes.features.push(destination(centerPt, miles, 90, 'miles'));
-    spokes.features.push(destination(centerPt, miles, -90, 'miles'));
+    var spokes = featureCollection([]);
+    var km = (time/3600) * maxspeed;
+    spokes.features.push(destination(centerPt, km, 180, 'kilometers'));
+    spokes.features.push(destination(centerPt, km, 0, 'kilometers'));
+    spokes.features.push(destination(centerPt, km, 90, 'kilometers'));
+    spokes.features.push(destination(centerPt, km, -90, 'kilometers'));
     var bbox = extent(spokes);
 
     //compute destination grid
     var targets = grid(bbox, resolution);
-    var routes = featureCollection([]);
     var destinations = featureCollection([]);
     var i = 0;
     var routedNum = 0;
@@ -32,7 +33,7 @@ module.exports = function (center, time, resolution, network, done) {
 
     function getNext(i){
         if(destinations.length >= targets.length){
-            return
+            return;
         }
         if(i < targets.features.length) {
             var query = {
@@ -43,19 +44,20 @@ module.exports = function (center, time, resolution, network, done) {
                     [
                       targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]
                     ]
-                ]
+                ],
+                alternateRoute: false,
+                printInstructions: false
             };
         
             osrm.route(query, function(err, res){
                 i++;
-                if(err) console.log(err)
-                if(err) return done(err)
+                if(err) console.log(err);
+                if(err) return done(err);
                 else if (!res || !res.route_summary) {
                     destinations.features.push({
                         type: 'Feature',
                         properties: {
                             eta: time+100
-                            //,dist: 500
                         },
                         geometry: {
                             type: 'Point',
@@ -74,33 +76,12 @@ module.exports = function (center, time, resolution, network, done) {
                             coordinates: [res.via_points[1][1], res.via_points[1][0]]
                         }
                         });
-                    routes.features.push(decode(res));
                 }
                 getNext(i);
             });
         } else {
-            var line = isolines(destinations, 'eta', resolution, [time]);
+            var line = isolines(destinations, 'eta', resolution, times);
             return done(null, line);
         }
     }
-}
-
-function decode (res) {
-    var route = {
-        type: 'Feature',
-        geometry: {
-            type: 'LineString',
-            coordinates: polylineDecode(res.route_geometry)
-        },
-        properties: {
-            eta: res.route_summary.total_time,
-            dist: res.route_summary.total_distance
-        }
-    };
-    route.geometry.coordinates = route.geometry.coordinates.map(function(c){
-        var lon = c[1] * 0.1;
-        var lat = c[0] * 0.1;
-        return [lon, lat];
-    });
-    return route;
-}
+};


### PR DESCRIPTION
This adds a new argument to the function, setting `max_speed`, instead of assuming 70mph.

Also, instead of passing a single `time`, `times` can either be a single value (for backward compatibility) or an array of times (from smallest to largest), creating several breaks. (It looks like you already did this somehow from the image in your example, but I couldn't figure out anyway to do this without changing the code like I did.)