### PR TITLE
Allow passing a custom OSRM instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ isochrone(location, time, resolution, network, function(err, drivetime) {
   console.log(JSON.stringify(drivetime))
 });
 ```
+
+Alternativaly the `network` parameter can be an [OSRM](https://github.com/Project-OSRM/node-osrm) module instance. Allowing setup an OSRM with custom paramters, e.g. usage of shared-memory.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var isolines = require('turf-isolines'),
     OSRM = require('osrm');
 
 module.exports = function (center, time, resolution, network, done) {
-    var osrm = new OSRM(network);
+    var osrm = network instanceof OSRM ? network : new OSRM(network);
     // compute bbox
     // bbox should go out 1.4 miles in each direction for each minute
     // this will account for a driver going a bit above the max safe speed


### PR DESCRIPTION
The `network` parameter can be an [OSRM](https://github.com/Project-OSRM/node-osrm) module instance. Allowing setup an OSRM with custom parameters, e.g. usage of shared-memory.