### PR TITLE
Exclude not routed points to improve isochrone

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ var isochrone = require('osrm-isochrone');
 
 var resolution = 25; // sample resolution
 var time = 300; // 300 second drivetime (5 minutes)
+var maxspeed = '70'; // in 'unit'/hour
+var unit = 'miles'; // 'miles' or 'kilometers'
 var network = './dc.osrm' // prebuild dc osrm network file
 var location = [-77.02926635742188,38.90011780426885]; // center point
 
-isochrone(location, time, resolution, network, function(err, drivetime) {
+isochrone(location, time, resolution, maxspeed, unit, network, function(err, drivetime) {
   if(err) throw err;
   // a geojson linestring
   console.log(JSON.stringify(drivetime))

--- a/README.md
+++ b/README.md
@@ -42,3 +42,31 @@ isochrone(location, time, resolution, maxspeed, unit, network, function(err, dri
 ```
 
 Alternativaly the `network` parameter can be an [OSRM](https://github.com/Project-OSRM/node-osrm) module instance. Allowing setup an OSRM with custom paramters, e.g. usage of shared-memory.
+
+You can too define your own function to draw line/polygon instead of default:
+
+```js
+var concave = require('turf-concave');
+var Isochrone = require('osrm-isochrone');
+
+var resolution = 25; // sample resolution
+var time = 300; // 300 second drivetime (5 minutes)
+var maxspeed = '70'; // in 'unit'/hour
+var unit = 'miles'; // 'miles' or 'kilometers'
+var network = './dc.osrm' // prebuild dc osrm network file
+var location = [-77.02926635742188,38.90011780426885]; // center point
+
+var isochrone = new Isochrone(location, time, resolution, maxspeed, unit, network, function(err, drivetime) {
+  if(err) throw err;
+  // your geojson from draw overload
+  console.log(JSON.stringify(drivetime))
+});
+isochrone.draw = function(destinations) {
+  var inside = destinations.features.filter(function(feat) {
+    return feat.properties.eta <= time;
+  });
+  destinations.features = inside;
+  return concave(destinations, this.sizeCellGrid, unit);
+}
+isochrone.getIsochrone();
+```

--- a/index.js
+++ b/index.js
@@ -8,10 +8,14 @@ var isolines = require('turf-isolines'),
     polylineDecode = require('polyline').decode,
     OSRM = require('osrm');
 
-module.exports = function (center, time, resolution, maxspeed, unit, network, done) {
-    this.draw = function(destinations) {
-        return isolines(destinations, 'eta', resolution, [time]);
-    };
+module.exports = function (center, time, resolution, maxspeed, unit, network, done, options) {
+    if (options && options.draw) {
+        this.draw = options.draw;
+    } else {
+        this.draw = function(destinations) {
+            return isolines(destinations, 'eta', resolution, [time]);
+        };
+    }
     this.getIsochrone = function() {
         var osrm = network instanceof OSRM ? network : new OSRM(network);
         // compute bbox

--- a/index.js
+++ b/index.js
@@ -58,7 +58,9 @@ module.exports = function (center, time, resolution, maxspeed, unit, network, do
                                 [
                                   targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]
                                 ]
-                            ]
+                            ],
+                            alternateRoute: false,
+                            printInstructions: false
                         };
                     
                         osrm.route(query, function(err, res){

--- a/index.js
+++ b/index.js
@@ -43,78 +43,74 @@ module.exports = function (center, time, resolution, maxspeed, unit, network, do
                 return;
             }
             if(i < targets.features.length) {
-                osrm.locate([targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]], function (err, result) {
-                    var distanceMapped = 0;
-                    if (result && result.mapped_coordinate) {
-                        distanceMapped = distance(
-                            point(targets.features[i].geometry.coordinates[0], targets.features[i].geometry.coordinates[1]),
-                            point(result.mapped_coordinate[1], result.mapped_coordinate[0]),
-                            unit
-                        );
-                    }
-                    if (distanceMapped && distanceMapped < sizeCellGrid) {
-                        var query = {
-                            coordinates: [
-                                [
-                                  center[1], center[0]
-                                ],
-                                [
-                                  targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]
-                                ]
-                            ],
-                            alternateRoute: false,
-                            printInstructions: false
-                        };
-                    
-                        osrm.route(query, function(err, res){
-                            i++;
-                            if(err) console.log(err);
-                            if(err) return done(err);
-                            else if (!res || !res.route_summary) {
-                                destinations.features.push({
-                                    type: 'Feature',
-                                    properties: {
-                                        eta: time+100
-                                        //,dist: 500
-                                    },
-                                    geometry: {
-                                        type: 'Point',
-                                        coordinates: [query.coordinates[1][1], query.coordinates[1][0]]
-                                    }
-                                });
-                            } else {
-                                destinations.features.push({
-                                    type: 'Feature',
-                                    properties: {
-                                        eta: res.route_summary.total_time,
-                                        dist: res.route_summary.total_distance
-                                    },
-                                    geometry: {
-                                        type: 'Point',
-                                        coordinates: [res.via_points[1][1], res.via_points[1][0]]
-                                    }
-                                });
-                            }
-                            getNext(i);
-                        });
-                    }
-                    else {
-                        // exclude some points from grid for isoline
-                        if (!distanceMapped) distanceMapped = sizeCellGrid * 2;
+                var query = {
+                    coordinates: [
+                        [
+                          center[1], center[0]
+                        ],
+                        [
+                          targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]
+                        ]
+                    ],
+                    alternateRoute: false,
+                    printInstructions: false
+                };
+            
+                osrm.route(query, function(err, res){
+                    i++;
+                    if(err) console.log(err);
+                    if(err) return done(err);
+                    else if (!res || !res.route_summary) {
                         destinations.features.push({
                             type: 'Feature',
                             properties: {
-                                // this point cannot be routed => a penality 2 is applied to maxspeed
-                                eta: time + (distanceMapped - sizeCellGrid) / (maxspeed / 3600) * 2
+                                eta: time+100
+                                //,dist: 500
                             },
                             geometry: {
                                 type: 'Point',
-                                coordinates: [targets.features[i].geometry.coordinates[0], targets.features[i].geometry.coordinates[1]]
+                                coordinates: [query.coordinates[1][1], query.coordinates[1][0]]
                             }
                         });
-                        i++;
-                        getNext(i);
+                    } else {
+                        var distanceMapped = 0;
+                        if (res.via_points) {
+                            distanceMapped = distance(
+                                point(query.coordinates[1][1], query.coordinates[1][0]),
+                                point(res.via_points[1][1], res.via_points[1][0]),
+                                unit
+                            );
+                        }
+                        if (distanceMapped && distanceMapped < sizeCellGrid) {
+                            destinations.features.push({
+                                type: 'Feature',
+                                properties: {
+                                    eta: res.route_summary.total_time,
+                                    dist: res.route_summary.total_distance
+                                },
+                                geometry: {
+                                    type: 'Point',
+                                    coordinates: [res.via_points[1][1], res.via_points[1][0]]
+                                }
+                            });
+                        }
+                        else {
+                            // exclude some points from grid for isoline
+                            if (!distanceMapped) distanceMapped = sizeCellGrid * 2;
+                            destinations.features.push({
+                                type: 'Feature',
+                                properties: {
+                                    // this point cannot be routed => a penality 2 is applied to maxspeed
+                                    eta: time + (distanceMapped - sizeCellGrid) / (maxspeed / 3600) * 2
+                                },
+                                geometry: {
+                                    type: 'Point',
+                                    coordinates: [query.coordinates[1][1], query.coordinates[1][0]]
+                                }
+                            });
+                        }
                     }
+                    getNext(i);
                 });
             } else {
                 var result = self.draw(destinations);

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var isolines = require('turf-isolines'),
     grid = require('turf-grid'),
     destination = require('turf-destination'),
     point = require('turf-point'),
+    distance = require('turf-distance'),
     extent = require('turf-extent'),
     featureCollection = require('turf-featurecollection'),
     polylineDecode = require('polyline').decode,
@@ -20,6 +21,7 @@ module.exports = function (center, time, resolution, maxspeed, unit, network, do
     spokes.features.push(destination(centerPt, length, 90, unit));
     spokes.features.push(destination(centerPt, length, -90, unit));
     var bbox = extent(spokes);
+    var sizeCellGrid = distance(point(bbox[0], bbox[1]), point(bbox[0], bbox[3]), unit) / resolution;
 
     //compute destination grid
     var targets = grid(bbox, resolution);
@@ -34,47 +36,76 @@ module.exports = function (center, time, resolution, maxspeed, unit, network, do
             return;
         }
         if(i < targets.features.length) {
-            var query = {
-                coordinates: [
-                    [
-                      center[1], center[0]
-                    ],
-                    [
-                      targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]
-                    ]
-                ]
-            };
-        
-            osrm.route(query, function(err, res){
-                i++;
-                if(err) console.log(err);
-                if(err) return done(err);
-                else if (!res || !res.route_summary) {
-                    destinations.features.push({
-                        type: 'Feature',
-                        properties: {
-                            eta: time+100
-                            //,dist: 500
-                        },
-                        geometry: {
-                            type: 'Point',
-                            coordinates: [query.coordinates[1][1], query.coordinates[1][0]]
+            osrm.locate([targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]], function (err, result) {
+                var distanceMapped = 0;
+                if (result && result.mapped_coordinate) {
+                    distanceMapped = distance(
+                        point(targets.features[i].geometry.coordinates[0], targets.features[i].geometry.coordinates[1]),
+                        point(result.mapped_coordinate[1], result.mapped_coordinate[0]),
+                        unit
+                    );
+                }
+                if (distanceMapped && distanceMapped < sizeCellGrid) {
+                    var query = {
+                        coordinates: [
+                            [
+                              center[1], center[0]
+                            ],
+                            [
+                              targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]
+                            ]
+                        ]
+                    };
+                
+                    osrm.route(query, function(err, res){
+                        i++;
+                        if(err) console.log(err);
+                        if(err) return done(err);
+                        else if (!res || !res.route_summary) {
+                            destinations.features.push({
+                                type: 'Feature',
+                                properties: {
+                                    eta: time+100
+                                    //,dist: 500
+                                },
+                                geometry: {
+                                    type: 'Point',
+                                    coordinates: [query.coordinates[1][1], query.coordinates[1][0]]
+                                }
+                            });
+                        } else {
+                            destinations.features.push({
+                                type: 'Feature',
+                                properties: {
+                                    eta: res.route_summary.total_time,
+                                    dist: res.route_summary.total_distance
+                                },
+                                geometry: {
+                                    type: 'Point',
+                                    coordinates: [res.via_points[1][1], res.via_points[1][0]]
+                                }
+                            });
                         }
-                    });
-                } else {
-                    destinations.features.push({
-                        type: 'Feature',
-                        properties: {
-                            eta: res.route_summary.total_time,
-                            dist: res.route_summary.total_distance
-                        },
-                        geometry: {
-                            type: 'Point',
-                            coordinates: [res.via_points[1][1], res.via_points[1][0]]
-                        }
+                        getNext(i);
                     });
                 }
-                getNext(i);
+                else {
+                    // exclude some points from grid for isoline
+                    if (!distanceMapped) distanceMapped = sizeCellGrid * 2;
+                    destinations.features.push({
+                        type: 'Feature',
+                        properties: {
+                            // this point cannot be routed => a penality 2 is applied to maxspeed
+                            eta: time + (distanceMapped - sizeCellGrid) / (maxspeed / 3600) * 2
+                        },
+                        geometry: {
+                            type: 'Point',
+                            coordinates: [targets.features[i].geometry.coordinates[0], targets.features[i].geometry.coordinates[1]]
+                        }
+                    });
+                    i++;
+                    getNext(i);
+                }
             });
         } else {
             var line = isolines(destinations, 'eta', resolution, [time]);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function (center, time, resolution, network, done) {
     // bbox should go out 1.4 miles in each direction for each minute
     // this will account for a driver going a bit above the max safe speed
     var centerPt = point(center[0], center[1]);
-    var spokes = featureCollection([])
+    var spokes = featureCollection([]);
     var miles = (time/60) * 1.2; // assume 70mph max speed
     spokes.features.push(destination(centerPt, miles, 180, 'miles'));
     spokes.features.push(destination(centerPt, miles, 0, 'miles'));
@@ -23,7 +23,6 @@ module.exports = function (center, time, resolution, network, done) {
 
     //compute destination grid
     var targets = grid(bbox, resolution);
-    var routes = featureCollection([]);
     var destinations = featureCollection([]);
     var i = 0;
     var routedNum = 0;
@@ -32,7 +31,7 @@ module.exports = function (center, time, resolution, network, done) {
 
     function getNext(i){
         if(destinations.length >= targets.length){
-            return
+            return;
         }
         if(i < targets.features.length) {
             var query = {
@@ -48,8 +47,8 @@ module.exports = function (center, time, resolution, network, done) {
         
             osrm.route(query, function(err, res){
                 i++;
-                if(err) console.log(err)
-                if(err) return done(err)
+                if(err) console.log(err);
+                if(err) return done(err);
                 else if (!res || !res.route_summary) {
                     destinations.features.push({
                         type: 'Feature',
@@ -73,8 +72,7 @@ module.exports = function (center, time, resolution, network, done) {
                             type: 'Point',
                             coordinates: [res.via_points[1][1], res.via_points[1][0]]
                         }
-                        });
-                    routes.features.push(decode(res));
+                    });
                 }
                 getNext(i);
             });
@@ -83,24 +81,4 @@ module.exports = function (center, time, resolution, network, done) {
             return done(null, line);
         }
     }
-}
-
-function decode (res) {
-    var route = {
-        type: 'Feature',
-        geometry: {
-            type: 'LineString',
-            coordinates: polylineDecode(res.route_geometry)
-        },
-        properties: {
-            eta: res.route_summary.total_time,
-            dist: res.route_summary.total_distance
-        }
-    };
-    route.geometry.coordinates = route.geometry.coordinates.map(function(c){
-        var lon = c[1] * 0.1;
-        var lat = c[0] * 0.1;
-        return [lon, lat];
-    });
-    return route;
 }

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = function (center, time, resolution, maxspeed, unit, network, do
                             }
                         });
                     } else {
-                        var distanceMapped = 0;
+                        var distanceMapped = undefined;
                         if (res.via_points) {
                             distanceMapped = distance(
                                 point(query.coordinates[1][1], query.coordinates[1][0]),
@@ -85,7 +85,7 @@ module.exports = function (center, time, resolution, maxspeed, unit, network, do
                                 unit
                             );
                         }
-                        if (distanceMapped && distanceMapped < sizeCellGrid) {
+                        if (distanceMapped !== undefined && distanceMapped < sizeCellGrid) {
                             destinations.features.push({
                                 type: 'Feature',
                                 properties: {

--- a/index.js
+++ b/index.js
@@ -9,107 +9,117 @@ var isolines = require('turf-isolines'),
     OSRM = require('osrm');
 
 module.exports = function (center, time, resolution, maxspeed, unit, network, done) {
-    var osrm = network instanceof OSRM ? network : new OSRM(network);
-    // compute bbox
-    // bbox should go out 1.4 miles in each direction for each minute
-    // this will account for a driver going a bit above the max safe speed
-    var centerPt = point(center[0], center[1]);
-    var spokes = featureCollection([]);
-    var length = (time/3600) * maxspeed;
-    spokes.features.push(destination(centerPt, length, 180, unit));
-    spokes.features.push(destination(centerPt, length, 0, unit));
-    spokes.features.push(destination(centerPt, length, 90, unit));
-    spokes.features.push(destination(centerPt, length, -90, unit));
-    var bbox = extent(spokes);
-    var sizeCellGrid = distance(point(bbox[0], bbox[1]), point(bbox[0], bbox[3]), unit) / resolution;
+    this.draw = function(destinations) {
+        return isolines(destinations, 'eta', resolution, [time]);
+    };
+    this.getIsochrone = function() {
+        var osrm = network instanceof OSRM ? network : new OSRM(network);
+        // compute bbox
+        // bbox should go out 1.4 miles in each direction for each minute
+        // this will account for a driver going a bit above the max safe speed
+        var centerPt = point(center[0], center[1]);
+        var spokes = featureCollection([]);
+        var length = (time/3600) * maxspeed;
+        spokes.features.push(destination(centerPt, length, 180, unit));
+        spokes.features.push(destination(centerPt, length, 0, unit));
+        spokes.features.push(destination(centerPt, length, 90, unit));
+        spokes.features.push(destination(centerPt, length, -90, unit));
+        var bbox = this.bbox = extent(spokes);
+        var sizeCellGrid = this.sizeCellGrid = distance(point(bbox[0], bbox[1]), point(bbox[0], bbox[3]), unit) / resolution;
 
-    //compute destination grid
-    var targets = grid(bbox, resolution);
-    var destinations = featureCollection([]);
-    var i = 0;
-    var routedNum = 0;
+        //compute destination grid
+        var targets = grid(bbox, resolution);
+        var destinations = featureCollection([]);
+        var i = 0;
+        var routedNum = 0;
 
-    getNext(i);
+        getNext(i);
 
-    function getNext(i){
-        if(destinations.length >= targets.length){
-            return;
-        }
-        if(i < targets.features.length) {
-            osrm.locate([targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]], function (err, result) {
-                var distanceMapped = 0;
-                if (result && result.mapped_coordinate) {
-                    distanceMapped = distance(
-                        point(targets.features[i].geometry.coordinates[0], targets.features[i].geometry.coordinates[1]),
-                        point(result.mapped_coordinate[1], result.mapped_coordinate[0]),
-                        unit
-                    );
-                }
-                if (distanceMapped && distanceMapped < sizeCellGrid) {
-                    var query = {
-                        coordinates: [
-                            [
-                              center[1], center[0]
-                            ],
-                            [
-                              targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]
+        function getNext(i){
+            if(destinations.length >= targets.length){
+                return;
+            }
+            if(i < targets.features.length) {
+                osrm.locate([targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]], function (err, result) {
+                    var distanceMapped = 0;
+                    if (result && result.mapped_coordinate) {
+                        distanceMapped = distance(
+                            point(targets.features[i].geometry.coordinates[0], targets.features[i].geometry.coordinates[1]),
+                            point(result.mapped_coordinate[1], result.mapped_coordinate[0]),
+                            unit
+                        );
+                    }
+                    if (distanceMapped && distanceMapped < sizeCellGrid) {
+                        var query = {
+                            coordinates: [
+                                [
+                                  center[1], center[0]
+                                ],
+                                [
+                                  targets.features[i].geometry.coordinates[1], targets.features[i].geometry.coordinates[0]
+                                ]
                             ]
-                        ]
-                    };
-                
-                    osrm.route(query, function(err, res){
+                        };
+                    
+                        osrm.route(query, function(err, res){
+                            i++;
+                            if(err) console.log(err);
+                            if(err) return done(err);
+                            else if (!res || !res.route_summary) {
+                                destinations.features.push({
+                                    type: 'Feature',
+                                    properties: {
+                                        eta: time+100
+                                        //,dist: 500
+                                    },
+                                    geometry: {
+                                        type: 'Point',
+                                        coordinates: [query.coordinates[1][1], query.coordinates[1][0]]
+                                    }
+                                });
+                            } else {
+                                destinations.features.push({
+                                    type: 'Feature',
+                                    properties: {
+                                        eta: res.route_summary.total_time,
+                                        dist: res.route_summary.total_distance
+                                    },
+                                    geometry: {
+                                        type: 'Point',
+                                        coordinates: [res.via_points[1][1], res.via_points[1][0]]
+                                    }
+                                });
+                            }
+                            getNext(i);
+                        });
+                    }
+                    else {
+                        // exclude some points from grid for isoline
+                        if (!distanceMapped) distanceMapped = sizeCellGrid * 2;
+                        destinations.features.push({
+                            type: 'Feature',
+                            properties: {
+                                // this point cannot be routed => a penality 2 is applied to maxspeed
+                                eta: time + (distanceMapped - sizeCellGrid) / (maxspeed / 3600) * 2
+                            },
+                            geometry: {
+                                type: 'Point',
+                                coordinates: [targets.features[i].geometry.coordinates[0], targets.features[i].geometry.coordinates[1]]
+                            }
+                        });
                         i++;
-                        if(err) console.log(err);
-                        if(err) return done(err);
-                        else if (!res || !res.route_summary) {
-                            destinations.features.push({
-                                type: 'Feature',
-                                properties: {
-                                    eta: time+100
-                                    //,dist: 500
-                                },
-                                geometry: {
-                                    type: 'Point',
-                                    coordinates: [query.coordinates[1][1], query.coordinates[1][0]]
-                                }
-                            });
-                        } else {
-                            destinations.features.push({
-                                type: 'Feature',
-                                properties: {
-                                    eta: res.route_summary.total_time,
-                                    dist: res.route_summary.total_distance
-                                },
-                                geometry: {
-                                    type: 'Point',
-                                    coordinates: [res.via_points[1][1], res.via_points[1][0]]
-                                }
-                            });
-                        }
                         getNext(i);
-                    });
-                }
-                else {
-                    // exclude some points from grid for isoline
-                    if (!distanceMapped) distanceMapped = sizeCellGrid * 2;
-                    destinations.features.push({
-                        type: 'Feature',
-                        properties: {
-                            // this point cannot be routed => a penality 2 is applied to maxspeed
-                            eta: time + (distanceMapped - sizeCellGrid) / (maxspeed / 3600) * 2
-                        },
-                        geometry: {
-                            type: 'Point',
-                            coordinates: [targets.features[i].geometry.coordinates[0], targets.features[i].geometry.coordinates[1]]
-                        }
-                    });
-                    i++;
-                    getNext(i);
-                }
-            });
-        } else {
-            var line = isolines(destinations, 'eta', resolution, [time]);
-            return done(null, line);
+                    }
+                });
+            } else {
+                var result = self.draw(destinations);
+                return done(null, result);
+            }
         }
-    }
+    };
+    var self = this;
+
+    // in case module is called directly
+    if (this.process && this.process.title == 'node')
+        return getIsochrone();
 }

--- a/index.js
+++ b/index.js
@@ -7,18 +7,18 @@ var isolines = require('turf-isolines'),
     polylineDecode = require('polyline').decode,
     OSRM = require('osrm');
 
-module.exports = function (center, time, resolution, network, done) {
+module.exports = function (center, time, resolution, maxspeed, unit, network, done) {
     var osrm = network instanceof OSRM ? network : new OSRM(network);
     // compute bbox
     // bbox should go out 1.4 miles in each direction for each minute
     // this will account for a driver going a bit above the max safe speed
     var centerPt = point(center[0], center[1]);
     var spokes = featureCollection([]);
-    var miles = (time/60) * 1.2; // assume 70mph max speed
-    spokes.features.push(destination(centerPt, miles, 180, 'miles'));
-    spokes.features.push(destination(centerPt, miles, 0, 'miles'));
-    spokes.features.push(destination(centerPt, miles, 90, 'miles'));
-    spokes.features.push(destination(centerPt, miles, -90, 'miles'));
+    var length = (time/3600) * maxspeed;
+    spokes.features.push(destination(centerPt, length, 180, unit));
+    spokes.features.push(destination(centerPt, length, 0, unit));
+    spokes.features.push(destination(centerPt, length, 90, unit));
+    spokes.features.push(destination(centerPt, length, -90, unit));
     var bbox = extent(spokes);
 
     //compute destination grid

--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ module.exports = function (center, time, resolution, maxspeed, unit, network, do
 
         //compute destination grid
         var targets = grid(bbox, resolution);
+        targets.features = targets.features.filter(function(feat) {
+            return distance(point(feat.geometry.coordinates[0], feat.geometry.coordinates[1]), centerPt, unit) <= length;
+        });
         var destinations = featureCollection([]);
         var i = 0;
         var routedNum = 0;
@@ -36,7 +39,7 @@ module.exports = function (center, time, resolution, maxspeed, unit, network, do
         getNext(i);
 
         function getNext(i){
-            if(destinations.length >= targets.length){
+            if(destinations.features.length > targets.features.length){
                 return;
             }
             if(i < targets.features.length) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "turf-grid": "^0.1.0",
     "turf-isolines": "^0.1.1",
     "turf-point": "^0.1.6",
-    "turf-quantile": "^0.1.1"
+    "turf-quantile": "^0.1.1",
+    "turf-distance": "^0.1.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -5,13 +5,15 @@ var test = require('tape'),
 test('osrm-isochrone', function(t) {
     var resolution = 35;
     var time = 300; // 5 minute drivetime
+    var maxspeed = 70;
+    var unit = 'miles';
     var network = '../dc.osrm'
     var locations = [
         [-77.02926635742188,38.90011780426885]
     ];
 
     locations.forEach(function(location) {
-        isochrone(location, time, resolution, network, function(err, drivetime) {
+        isochrone(location, time, resolution, maxspeed, unit, network, function(err, drivetime) {
             if(err) throw err;
             t.ok(drivetime);
             console.log(JSON.stringify(drivetime))


### PR DESCRIPTION
Hello,
here in this branch I've commited several improvements: 
- take into account maxspeed
- exclude points which are not routed (ie : if they are mapped on a road with a distance more than the cell  size). This improvement is very usefull in mountains zones for instance with turf-isolines function used to draw the isochrone.
- ability to define another way to draw isochrones. Turf-isolines seems not to be performant :( With this commit, caller can define its own function instead of turf-isolines. But default behavior is still to draw isochrones with isolines as before.

Regards,
Fabien